### PR TITLE
feat(models): define data layer

### DIFF
--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class ApplicationRecord < ActiveRecord::Base
+  primary_abstract_class
+end

--- a/app/models/final_frame.rb
+++ b/app/models/final_frame.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class FinalFrame < Frame
+  MAX_ROLLS_PER_FRAME = 3
+
+  attribute :frame_number, :integer, default: 10
+
+  private
+
+  def max_roll_count
+    3
+  end
+end

--- a/app/models/frame.rb
+++ b/app/models/frame.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+class Frame < ApplicationRecord
+  MIN_FRAME_NUMBER = 0
+  MAX_FRAME_NUMBER = 10
+  MIN_SCORE_PER_FRAME = 0
+  MAX_SCORE_PER_FRAME = 30
+
+  TYPES = {
+    Frame: 'Frame',
+    FinalFrame: 'FinalFrame'
+  }.freeze
+
+  attribute :completed, :boolean, default: false
+  attribute :frame_number, :integer
+  attribute :score, :integer, default: 0
+  attribute :type, :string, default: -> { TYPES[:Frame] }
+
+  belongs_to :game
+  has_many :rolls, dependent: :destroy, validate: true
+
+  scope :completed, -> { where(completed: true) }
+  scope :incomplete, -> { where(completed: false) }
+
+  scope :final_frame, -> { where(type: TYPES[:FinalFrame]) }
+
+  validate :validate_roll_count
+  validates :frame_number, :score, :type,
+            presence: true
+  validates :frame_number, numericality: {
+    greater_than_or_equal_to: MIN_FRAME_NUMBER,
+    less_than_or_equal_to: MAX_FRAME_NUMBER
+  }
+  validates :score, numericality: {
+    greater_than_or_equal_to: MIN_SCORE_PER_FRAME,
+    less_than_or_equal_to: MAX_SCORE_PER_FRAME,
+    message: 'Score must be between 0 and 30'
+  }
+
+  private
+
+  def max_roll_count
+    2
+  end
+
+  def validate_roll_count
+    errors.add(:rolls, "cannot have more than #{max_roll_count} rolls") if rolls.size > max_roll_count
+  end
+end

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class Game < ApplicationRecord
+  after_create :create_frames
+  has_many :frames, dependent: :destroy
+
+  def current_frame
+    frames.incomplete.first
+  end
+
+  private
+
+  def create_frames
+    9.times { |index| frames.create!(frame_number: index + 1, type: Frame::TYPES[:Frame]) }
+    frames.create!(frame_number: 10, type: Frame::TYPES[:FinalFrame])
+  end
+end

--- a/app/models/roll.rb
+++ b/app/models/roll.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class Roll < ApplicationRecord
+  MIN_PINS_PER_ROLL = 0
+  MAX_PINS_PER_ROLL = 10
+
+  belongs_to :frame
+
+  attribute :pins
+
+  validates :pins, numericality: {
+    greater_than_or_equal_to: MIN_PINS_PER_ROLL,
+    less_than_or_equal_to: MAX_PINS_PER_ROLL
+  }
+end

--- a/db/migrate/20250217214649_create_games.rb
+++ b/db/migrate/20250217214649_create_games.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class CreateGames < ActiveRecord::Migration[8.0]
+  def change
+    create_table :games do |t|
+      t.boolean :completed
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250217214656_create_frames.rb
+++ b/db/migrate/20250217214656_create_frames.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class CreateFrames < ActiveRecord::Migration[8.0]
+  def change
+    create_table :frames do |t|
+      t.references :game, null: false, foreign_key: true
+      t.timestamps
+      t.boolean :completed, null: false
+      t.integer :frame_number, null: false
+      t.integer :score, null: false
+      t.string :type, null: false
+    end
+  end
+end

--- a/db/migrate/20250217214702_create_rolls.rb
+++ b/db/migrate/20250217214702_create_rolls.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class CreateRolls < ActiveRecord::Migration[8.0]
+  def change
+    create_table :rolls do |t|
+      t.references :frame, null: false, foreign_key: true
+      t.integer :pins, null: false
+      t.timestamps
+    end
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1,0 +1,18 @@
+CREATE TABLE IF NOT EXISTS "schema_migrations" ("version" varchar NOT NULL PRIMARY KEY);
+CREATE TABLE IF NOT EXISTS "ar_internal_metadata" ("key" varchar NOT NULL PRIMARY KEY, "value" varchar, "created_at" datetime(6) NOT NULL, "updated_at" datetime(6) NOT NULL);
+CREATE TABLE IF NOT EXISTS "games" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "completed" boolean, "created_at" datetime(6) NOT NULL, "updated_at" datetime(6) NOT NULL);
+CREATE TABLE IF NOT EXISTS "frames" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "game_id" integer NOT NULL, "created_at" datetime(6) NOT NULL, "updated_at" datetime(6) NOT NULL, "completed" boolean NOT NULL, "frame_number" integer NOT NULL, "score" integer NOT NULL, "type" varchar NOT NULL, CONSTRAINT "fk_rails_ee0b37ac02"
+FOREIGN KEY ("game_id")
+  REFERENCES "games" ("id")
+);
+CREATE INDEX "index_frames_on_game_id" ON "frames" ("game_id") /*application='BowlingScorekeeper'*/;
+CREATE TABLE IF NOT EXISTS "rolls" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "frame_id" integer NOT NULL, "pins" integer NOT NULL, "created_at" datetime(6) NOT NULL, "updated_at" datetime(6) NOT NULL, CONSTRAINT "fk_rails_f09717ac94"
+FOREIGN KEY ("frame_id")
+  REFERENCES "frames" ("id")
+);
+CREATE INDEX "index_rolls_on_frame_id" ON "rolls" ("frame_id") /*application='BowlingScorekeeper'*/;
+INSERT INTO "schema_migrations" (version) VALUES
+('20250217214702'),
+('20250217214656'),
+('20250217214649');
+

--- a/spec/models/final_frame_spec.rb
+++ b/spec/models/final_frame_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe FinalFrame, type: :model do
+  it 'has the correct default frame_number' do
+    final_frame = FinalFrame.build
+    expect(final_frame.frame_number).to eq(10)
+  end
+
+  it 'validates the number of rolls' do
+    final_frame = FinalFrame.build( score: 30)
+    4.times { final_frame.rolls << Roll.build }
+    expect(final_frame).not_to be_valid
+    expect(final_frame.errors[:rolls]).to include('cannot have more than 3 rolls')
+  end
+end

--- a/spec/models/frame_spec.rb
+++ b/spec/models/frame_spec.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Frame, type: :model do
+  game =  Game.build
+  frame = Frame.build(completed: false, frame_number: 1, game:, score: 0)
+
+  it 'has a valid factory' do
+    expect(frame).to be_valid
+  end
+
+  it 'belongs to a game' do
+    association = described_class.reflect_on_association(:game)
+    expect(association.macro).to eq(:belongs_to)
+  end
+
+  it 'has many rolls and they are dependent destroy' do
+    association = described_class.reflect_on_association(:rolls)
+    expect(association.macro).to eq(:has_many)
+    expect(association.options[:dependent]).to eq :destroy
+  end
+
+  it 'has the correct default type' do
+    expect(frame.type).to eq('Frame')
+  end
+
+  describe 'validates' do
+    it 'validates presence of frame_number' do
+      frame = Frame.new(frame_number: nil)
+      expect(frame).to_not be_valid
+      expect(frame.errors[:frame_number]).to include('can\'t be blank')
+    end
+
+    it 'validates presence of score' do
+      frame = Frame.new(score: nil)
+      expect(frame).to_not be_valid
+      expect(frame.errors[:score]).to include('can\'t be blank')
+    end
+
+    it 'validates presence of type' do
+      frame = Frame.new(type: nil)
+      expect(frame).to_not be_valid
+      expect(frame.errors[:type]).to include('can\'t be blank')
+    end
+
+    it 'validates numericality of frame_number' do
+      frame.frame_number = -1
+      expect(frame).not_to be_valid
+      expect(frame.errors[:frame_number]).to include('must be greater than or equal to 0')
+
+      frame.frame_number = 11
+      expect(frame).not_to be_valid
+      expect(frame.errors[:frame_number]).to include('must be less than or equal to 10')
+    end
+
+    it 'validates numericality of score' do
+      frame.score = -1
+      expect(frame).not_to be_valid
+      expect(frame.errors[:score].first).to include('must be between 0 and 30')
+
+      frame.score = 31
+      expect(frame).not_to be_valid
+      expect(frame.errors[:score].first).to include('must be between 0 and 30')
+    end
+
+    it 'validates the number of rolls' do
+      3.times { frame.rolls << Roll.build(pins: (1..10).to_a.sample) }
+      expect(frame).not_to be_valid
+      expect(frame.errors[:rolls]).to include('cannot have more than 2 rolls')
+    end
+  end
+
+  describe 'scopes' do
+    describe '.completed' do
+      final_frame = FinalFrame.create(game:, completed: true)
+
+      it 'returns only FinalFrame records' do
+        expect(Frame.completed.last).to eq(final_frame)
+      end
+    end
+  end
+end

--- a/spec/models/game_spec.rb
+++ b/spec/models/game_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Game, type: :model do
+  describe 'associations' do
+    it 'has many frames' do
+      association = described_class.reflect_on_association(:frames)
+      expect(association.macro).to eq(:has_many)
+    end
+
+    it 'destroys frames when the game is destroyed' do
+      game = Game.create
+      expect { game.destroy }.to change(Frame,:count).by(-10)
+    end
+  end
+
+  describe '#create_frames' do
+    game = Game.create
+
+    it 'creates 10 frames after game creation' do
+      expect(game.frames.count).to eq(10)
+    end
+
+    it 'creates 9 regular frames and 1 final frame' do
+      expect(game.frames.where(type: 'Frame').count).to eq(9)
+      expect(game.frames.where(type: 'FinalFrame').count).to eq(1)
+    end
+
+    it 'assigns the correct frame numbers' do
+      expect(game.frames.pluck(:frame_number)).to eq((1..10).to_a)
+    end
+  end
+
+  describe '#current_frame' do
+    game = Game.create
+
+    context 'when no frames are completed' do
+      it 'returns the first frame' do
+        expect(game.current_frame.frame_number).to eq(1)
+      end
+    end
+
+    context 'when some frames are completed' do
+      before do
+        game.frames.first.update!(completed: true)
+      end
+
+      it 'returns the next incomplete frame' do
+        expect(game.current_frame.frame_number).to eq(2)
+      end
+    end
+
+    context 'when all frames are completed' do
+      before do
+        game.frames.where(type: 'Frame').each { |frame| frame.update!(completed: true) }
+      end
+
+      it 'returns the last frame' do
+        expect(game.current_frame.frame_number).to eq(10)
+      end
+    end
+  end
+end

--- a/spec/models/roll_spec.rb
+++ b/spec/models/roll_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Roll, type: :model do
+  it 'belongs to a frame' do
+    association = described_class.reflect_on_association(:frame)
+    expect(association.macro).to eq(:belongs_to)
+  end
+
+  describe 'validations' do
+    it 'validates numericality of pins' do
+      roll = Roll.new(pins: -1)
+      expect(roll).not_to be_valid
+      expect(roll.errors[:pins]).to include('must be greater than or equal to 0')
+
+      roll.pins = 11
+      expect(roll).not_to be_valid
+      expect(roll.errors[:pins]).to include('must be less than or equal to 10')
+    end
+  end
+end


### PR DESCRIPTION
Defines the data layer structure.  We are persisting the data atm but we have no **real** reason to.  I suppose my reason behind this is that the data would more than likely want to be retained for scores and skill analysis/trends.  Also, more than likely a `player` and `name` would exist, with some sort of an `id` to bind those to the games and frames.  

- define game, which has many frames
- define frames, which has many rolls
- define rolls, which contains a `pins` score ( could have just been score but i like pins =) )

first pass at db structure, hopefully good 👍🏼 