### PR TITLE
build(dry-rb): add dry-rb

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,8 @@
 source "https://rubygems.org"
 
 gem "active_model_serializers"
+gem "dry-monads"
+gem "dry-schema"
 gem "puma", ">= 5.0"
 gem "rails", "~> 8.0.1"
 gem "rack-cors"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -95,6 +95,39 @@ GEM
       reline (>= 0.3.8)
     diff-lcs (1.6.0)
     drb (2.2.1)
+    dry-configurable (1.3.0)
+      dry-core (~> 1.1)
+      zeitwerk (~> 2.6)
+    dry-core (1.1.0)
+      concurrent-ruby (~> 1.0)
+      logger
+      zeitwerk (~> 2.6)
+    dry-inflector (1.2.0)
+    dry-initializer (3.2.0)
+    dry-logic (1.6.0)
+      bigdecimal
+      concurrent-ruby (~> 1.0)
+      dry-core (~> 1.1)
+      zeitwerk (~> 2.6)
+    dry-monads (1.7.1)
+      concurrent-ruby (~> 1.0)
+      dry-core (~> 1.1)
+      zeitwerk (~> 2.6)
+    dry-schema (1.14.0)
+      concurrent-ruby (~> 1.0)
+      dry-configurable (~> 1.0, >= 1.0.1)
+      dry-core (~> 1.1)
+      dry-initializer (~> 3.2)
+      dry-logic (~> 1.5)
+      dry-types (~> 1.8)
+      zeitwerk (~> 2.6)
+    dry-types (1.8.2)
+      bigdecimal (~> 3.0)
+      concurrent-ruby (~> 1.0)
+      dry-core (~> 1.0)
+      dry-inflector (~> 1.0)
+      dry-logic (~> 1.4)
+      zeitwerk (~> 2.6)
     erubi (1.13.1)
     et-orbi (1.2.11)
       tzinfo
@@ -310,6 +343,8 @@ DEPENDENCIES
   active_model_serializers
   brakeman
   debug
+  dry-monads
+  dry-schema
   puma (>= 5.0)
   rack-cors
   rails (~> 8.0.1)


### PR DESCRIPTION
- adds [dry-rb ](https://dry-rb.org/) for operation (fancy service objects) structure
  - [dry schemas](https://dry-rb.org/gems/dry-schema/1.13/)
  - [dry monads](https://dry-rb.org/gems/dry-monads/1.6/)
-  plan to use monads to relieve some of the 'business logic' complexity
