### PR TITLE
refinement(data-models): refine structure, specs

### DIFF
--- a/app/models/frame.rb
+++ b/app/models/frame.rb
@@ -12,16 +12,17 @@ class Frame < ApplicationRecord
   }.freeze
 
   attribute :completed, :boolean, default: false
+  attribute :created_at, :datetime
   attribute :frame_number, :integer
   attribute :score, :integer, default: 0
   attribute :type, :string, default: -> { TYPES[:Frame] }
+  attribute :updated_at, :datetime
 
   belongs_to :game
   has_many :rolls, dependent: :destroy, validate: true
 
   scope :completed, -> { where(completed: true) }
   scope :incomplete, -> { where(completed: false) }
-
   scope :final_frame, -> { where(type: TYPES[:FinalFrame]) }
 
   validate :validate_roll_count
@@ -29,13 +30,18 @@ class Frame < ApplicationRecord
             presence: true
   validates :frame_number, numericality: {
     greater_than_or_equal_to: MIN_FRAME_NUMBER,
-    less_than_or_equal_to: MAX_FRAME_NUMBER
+    less_than_or_equal_to: MAX_FRAME_NUMBER,
+    message: "must be between #{MIN_FRAME_NUMBER} and #{MAX_FRAME_NUMBER}"
   }
   validates :score, numericality: {
     greater_than_or_equal_to: MIN_SCORE_PER_FRAME,
     less_than_or_equal_to: MAX_SCORE_PER_FRAME,
-    message: 'Score must be between 0 and 30'
+    message: "must be between #{MIN_SCORE_PER_FRAME} and #{MAX_SCORE_PER_FRAME}"
   }
+
+  def mark_as_completed?
+    self.rolls.count == max_roll_count
+  end
 
   private
 
@@ -44,6 +50,6 @@ class Frame < ApplicationRecord
   end
 
   def validate_roll_count
-    errors.add(:rolls, "cannot have more than #{max_roll_count} rolls") if rolls.size > max_roll_count
+    errors.add(:frames, "cannot have more than #{max_roll_count} rolls") if rolls.size > max_roll_count
   end
 end

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -2,10 +2,19 @@
 
 class Game < ApplicationRecord
   after_create :create_frames
+
+  attribute :completed, :boolean, default: false
+  attribute :created_at, :datetime
+  attribute :updated_at, :datetime
+
   has_many :frames, dependent: :destroy
 
   def current_frame
     frames.incomplete.first
+  end
+
+  def incomplete?
+    !completed?
   end
 
   private

--- a/app/models/roll.rb
+++ b/app/models/roll.rb
@@ -4,9 +4,11 @@ class Roll < ApplicationRecord
   MIN_PINS_PER_ROLL = 0
   MAX_PINS_PER_ROLL = 10
 
-  belongs_to :frame
-
+  attribute :created_at, :datetime
   attribute :pins
+  attribute :updated_at, :datetime
+
+  belongs_to :frame
 
   validates :pins, numericality: {
     greater_than_or_equal_to: MIN_PINS_PER_ROLL,

--- a/db/migrate/20250217214649_create_games.rb
+++ b/db/migrate/20250217214649_create_games.rb
@@ -3,7 +3,7 @@
 class CreateGames < ActiveRecord::Migration[8.0]
   def change
     create_table :games do |t|
-      t.boolean :completed
+      t.boolean :completed, null: false, default: false
       t.timestamps
     end
   end

--- a/db/migrate/20250217214656_create_frames.rb
+++ b/db/migrate/20250217214656_create_frames.rb
@@ -5,7 +5,7 @@ class CreateFrames < ActiveRecord::Migration[8.0]
     create_table :frames do |t|
       t.references :game, null: false, foreign_key: true
       t.timestamps
-      t.boolean :completed, null: false
+      t.boolean :completed, null: false, default: false
       t.integer :frame_number, null: false
       t.integer :score, null: false
       t.string :type, null: false

--- a/db/migrate/20250219030855_add_carry_over_rolls_to_frames.rb
+++ b/db/migrate/20250219030855_add_carry_over_rolls_to_frames.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddCarryOverRollsToFrames < ActiveRecord::Migration[8.0]
+  def change
+    change_table :frames do |t|
+      t.integer :carry_over_rolls
+    end
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1,7 +1,7 @@
 CREATE TABLE IF NOT EXISTS "schema_migrations" ("version" varchar NOT NULL PRIMARY KEY);
 CREATE TABLE IF NOT EXISTS "ar_internal_metadata" ("key" varchar NOT NULL PRIMARY KEY, "value" varchar, "created_at" datetime(6) NOT NULL, "updated_at" datetime(6) NOT NULL);
 CREATE TABLE IF NOT EXISTS "games" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "completed" boolean, "created_at" datetime(6) NOT NULL, "updated_at" datetime(6) NOT NULL);
-CREATE TABLE IF NOT EXISTS "frames" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "game_id" integer NOT NULL, "created_at" datetime(6) NOT NULL, "updated_at" datetime(6) NOT NULL, "completed" boolean NOT NULL, "frame_number" integer NOT NULL, "score" integer NOT NULL, "type" varchar NOT NULL, CONSTRAINT "fk_rails_ee0b37ac02"
+CREATE TABLE IF NOT EXISTS "frames" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "game_id" integer NOT NULL, "created_at" datetime(6) NOT NULL, "updated_at" datetime(6) NOT NULL, "completed" boolean NOT NULL, "frame_number" integer NOT NULL, "score" integer NOT NULL, "type" varchar NOT NULL, "carry_over_rolls" integer /*application='BowlingScorekeeper'*/, CONSTRAINT "fk_rails_ee0b37ac02"
 FOREIGN KEY ("game_id")
   REFERENCES "games" ("id")
 );
@@ -12,6 +12,7 @@ FOREIGN KEY ("frame_id")
 );
 CREATE INDEX "index_rolls_on_frame_id" ON "rolls" ("frame_id") /*application='BowlingScorekeeper'*/;
 INSERT INTO "schema_migrations" (version) VALUES
+('20250219030855'),
 ('20250217214702'),
 ('20250217214656'),
 ('20250217214649');

--- a/spec/models/final_frame_spec.rb
+++ b/spec/models/final_frame_spec.rb
@@ -12,6 +12,6 @@ RSpec.describe FinalFrame, type: :model do
     final_frame = FinalFrame.build( score: 30)
     4.times { final_frame.rolls << Roll.build }
     expect(final_frame).not_to be_valid
-    expect(final_frame.errors[:rolls]).to include('cannot have more than 3 rolls')
+    expect(final_frame.errors[:frames]).to include('cannot have more than 3 rolls')
   end
 end

--- a/spec/models/frame_spec.rb
+++ b/spec/models/frame_spec.rb
@@ -47,11 +47,11 @@ RSpec.describe Frame, type: :model do
     it 'validates numericality of frame_number' do
       frame.frame_number = -1
       expect(frame).not_to be_valid
-      expect(frame.errors[:frame_number]).to include('must be greater than or equal to 0')
+      expect(frame.errors[:frame_number]).to include('must be between 0 and 10')
 
       frame.frame_number = 11
       expect(frame).not_to be_valid
-      expect(frame.errors[:frame_number]).to include('must be less than or equal to 10')
+      expect(frame.errors[:frame_number]).to include('must be between 0 and 10')
     end
 
     it 'validates numericality of score' do
@@ -67,7 +67,8 @@ RSpec.describe Frame, type: :model do
     it 'validates the number of rolls' do
       3.times { frame.rolls << Roll.build(pins: (1..10).to_a.sample) }
       expect(frame).not_to be_valid
-      expect(frame.errors[:rolls]).to include('cannot have more than 2 rolls')
+      pp frame.errors
+      expect(frame.errors[:frames]).to include('cannot have more than 2 rolls')
     end
   end
 


### PR DESCRIPTION
- adds new db migration to prep for the carry_over frame logic for strikes and spares.
- refines some of the boolean to add null: false and default values.
- refines specs
- refines error messages