### PR TITLE
feat(controllers): expose endpoints and enforce contracts

### DIFF
--- a/app/contracts/game_contract.rb
+++ b/app/contracts/game_contract.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class GameContract  < Dry::Validation::Contract
+  params do
+    required(:game).filled
+  end
+
+  rule(:game) do
+    key.failure('invalid game.') unless value.is_a?(Game)
+    key.failure('game over man! game over!!') unless value.respond_to?(:incomplete?) && value.incomplete?
+  end
+end

--- a/app/contracts/roll_contract.rb
+++ b/app/contracts/roll_contract.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+class RollContract < Dry::Validation::Contract
+  PIN = Roll::PIN_CHARACTERS
+
+  option :game
+
+  params do
+    required(:pins).filled(:string)
+  end
+
+  rule(:pins) do
+    key.failure('must be a valid symbol (X, /, -) or a number between 0 and 10') unless acceptable_pin?(value)
+
+    if value == PIN[:SPARE]
+      key.failure('cannot be a spare on the first roll') if game.current_frame.rolls.empty?
+    elsif value.upcase == PIN[:STRIKE]
+      key.failure('cannot be a strike on the second roll') if game.current_frame.rolls.any?
+    end
+
+    if invalid_frame_score?(value)
+      key.failure("cannot exceed the frame score limit of #{Roll::MAX_PINS_PER_ROLL}")
+    end
+  end
+
+  private
+
+  def acceptable_pin?(value)
+    Roll::ACCEPTABLE_PIN_VALUES.include?(value)
+  end
+
+  # @todo: this could be reworked
+  def invalid_frame_score?(value)
+    non_character = PIN.values.exclude?(value)
+    exceeds_score_limit = value.to_i + game.current_frame.score > Roll::MAX_PINS_PER_ROLL
+
+    non_character && exceeds_score_limit
+  end
+end

--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module Api
+  # Base controller for API endpoints.
+  # Provides common methods and configurations for API controllers.
+  class BaseController <::ApplicationController
+    include ::Dry::Monads::Result::Mixin
+
+    private
+
+    # Renders a bad request response with the given message.
+    #
+    # @param errors [Hash] The error message to include in the response.
+    # @return [void]
+    def bad_request(errors = Hash[:status, 'Bad Request'])
+      render json: { errors: }, status: :bad_request
+    end
+
+    # Renders a created response with the given JSON data and serializer.
+    #
+    # @param json [Any] The JSON data to render.
+    # @return [void]
+    def created(json = {})
+      render json:, serializer:, status: :created
+    end
+
+    # Renders a not found response with the given message.
+    #
+    # @param errors [Any] The error message to include in the response.
+    # @return [void]
+    def not_found(errors = Hash[:status, 'Not Found'])
+      render json: { errors: }, status: :not_found
+    end
+  end
+end

--- a/app/controllers/api/v1/games_controller.rb
+++ b/app/controllers/api/v1/games_controller.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    class GamesController < ::Api::BaseController
+      attr_reader :game
+
+      before_action :game_exists?, only: [:roll]
+      before_action :validate_params, only: [:roll]
+
+      schemas[:roll] = Dry::Schema.Params do
+        required(:id).filled(:integer)
+        required(:pins).filled(:string)
+      end
+
+      def create
+        created(Game.create!)
+      end
+
+      def roll
+        result = Rolls::Record.new.call(game: game, pins: pins)
+        return bad_request(result.failure) unless result.success?
+
+        created(result.value!)
+      end
+
+      private
+
+      def game
+        @game ||= Game.includes(frames: :rolls).find(safe_params[:id])
+      end
+
+      def game_exists?
+        not_found unless game.present?
+      end
+
+      def pins
+        safe_params[:pins]
+      end
+
+      def serializer
+        GameJsonSerializer
+      end
+
+      def validate_params
+        result = GameContract.new.call(game:)
+        return bad_request(result.errors.to_h) if result.failure?
+
+        result = RollContract.new(game:).call(pins: pins)
+        bad_request(result.errors.to_h) if result.failure?
+      end
+    end
+  end
+end

--- a/config/initializers/routes.rb
+++ b/config/initializers/routes.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+Rails.application.routes.default_url_options[:host] = 'localhost:3000' # hard code for now, mostly for tests

--- a/spec/contracts/game_contract_spec.rb
+++ b/spec/contracts/game_contract_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe GameContract do
+  describe '#call' do
+    game = Game.build
+
+    context 'with a valid game' do
+      it 'succeeds' do
+        result = described_class.new.call(game: game)
+        expect(result).to be_success
+      end
+    end
+
+    context 'with an invalid game' do
+      it 'fails if the game is not a Game object' do
+        result = described_class.new.call(game: 'not a game')
+        expect(result).to be_failure
+        expect(result.errors[:game]).to include('invalid game.')
+      end
+
+      it 'fails if the game is over' do
+        game.completed = true
+        result = described_class.new.call(game: game)
+        expect(result).to be_failure
+        expect(result.errors[:game]).to include('game over man! game over!!')
+      end
+    end
+  end
+end

--- a/spec/contracts/roll_contract_spec.rb
+++ b/spec/contracts/roll_contract_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe RollContract do
+  describe '#call' do
+    game = Game.create!
+
+    describe '#call' do
+      context 'with valid input' do
+        it 'succeeds with valid numeric pins' do
+          result = described_class.new(game:).call({ pins: '5' })
+          expect(result).to be_success
+        end
+
+        it 'succeeds with a valid strike symbol on the first roll' do
+          result = described_class.new(game:).call({ pins: 'X' })
+          expect(result).to be_success
+        end
+
+        it 'succeeds with a valid spare symbol on the second roll' do
+          game.current_frame.rolls.create!(pins: 5)
+          result = described_class.new(game:).call({ pins: '/' })
+          expect(result).to be_success
+        end
+
+        it 'succeeds with a valid miss symbol' do
+          result = described_class.new(game:).call({ pins: '-' })
+          expect(result).to be_success
+        end
+      end
+
+      context 'with invalid input' do
+        it 'fails with an invalid pin value' do
+          result = described_class.new(game:).call({ pins: '12' })
+          expect(result).to be_failure
+          expect(result.errors[:pins]).to include('must be a valid symbol (X, /, -) or a number between 0 and 10')
+        end
+
+        it 'fails with a spare symbol on the first roll' do
+          result = described_class.new(game:).call({ pins: '/' })
+          expect(result).to be_failure
+          expect(result.errors[:pins]).to include('cannot be a spare on the first roll')
+        end
+
+        it 'fails with a strike symbol on the second roll' do
+          game.current_frame.rolls.create!(pins: 5)
+          result = described_class.new(game:).call({ pins: 'X' })
+          expect(result).to be_failure
+          expect(result.errors[:pins]).to include('cannot be a strike on the second roll')
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/api/v1/games_controller_spec.rb
+++ b/spec/requests/api/v1/games_controller_spec.rb
@@ -1,0 +1,54 @@
+# spec/requests/api/v1/games_controller_spec.rb
+require 'rails_helper'
+
+RSpec.describe Api::V1::GamesController, type: :request do
+  let(:json) { JSON.parse(response.body) }
+
+  describe 'POST #create' do
+    it 'creates a new game' do
+      expect { post api_v1_games_url }.to change(Game,:count).by(1)
+
+      expect(response).to have_http_status(:created)
+      expect(response.content_type).to eq('application/json; charset=utf-8')
+    end
+  end
+
+  describe 'POST #roll' do
+    let(:game) { Game.create! }
+
+    context 'with valid params' do
+      it 'records a roll and updates the game state' do
+        expect {
+          post roll_api_v1_game_url(game), params: { pins: '5' }
+        }.to change(Roll,:count).by(1)
+
+        expect(response).to have_http_status(:created)
+        expect(response.content_type).to eq('application/json; charset=utf-8')
+
+        game.reload
+        expect(game.current_frame.rolls.last.pins).to eq(5)
+      end
+    end
+
+    context 'with invalid params' do
+      it 'returns an error response for invalid pins' do
+        post roll_api_v1_game_url(game), params: { pins: '12' }
+        expect(response).to have_http_status(:bad_request)
+        expect(response.content_type).to eq('application/json; charset=utf-8')
+      end
+
+      it 'returns an error response for a non-existent game' do
+        post roll_api_v1_game_url('BREAK_THIS'), params: { pins: '5' }
+        expect(response).to have_http_status(:not_found)
+      end
+
+      it 'returns an error response for a game that is over' do
+        game.update!(completed: true)
+        post roll_api_v1_game_url(game), params: { pins: '5' }
+        expect(response).to have_http_status(:bad_request)
+        expect(response.content_type).to eq('application/json; charset=utf-8')
+        expect(json['errors']['game']).to include('game over man! game over!!')
+      end
+    end
+  end
+end


### PR DESCRIPTION
- expose the endpoints via the `GameController` and bind the `rolls` to the controller.
- separate the logic from the controller into contracts for validation
- helper functions in `base_controller`
  - `bad_request`
  - `created`
  - `not_found`
  - probably coulda been macros
- some tests